### PR TITLE
Break up the basic workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,5 +67,3 @@ For a typical 2-day workshop. Can be modified for different workshop formats.
 - Already-established SWC curricula: https://github.com/swcarpentry/swcarpentry#lesson-repositories
 - Lesson style guide: https://carpentries.github.io/lesson-example/06-style-guide/index.html
 - Guide to contributing with git and GitHub: https://github.com/dmgt/swc_github_flow/blob/master/for_novice_contributors.md#
-
-test 1 2

--- a/README.md
+++ b/README.md
@@ -67,3 +67,5 @@ For a typical 2-day workshop. Can be modified for different workshop formats.
 - Already-established SWC curricula: https://github.com/swcarpentry/swcarpentry#lesson-repositories
 - Lesson style guide: https://carpentries.github.io/lesson-example/06-style-guide/index.html
 - Guide to contributing with git and GitHub: https://github.com/dmgt/swc_github_flow/blob/master/for_novice_contributors.md#
+
+test 1 2

--- a/_episodes/03-intro-git-github.md
+++ b/_episodes/03-intro-git-github.md
@@ -21,10 +21,11 @@ keypoints:
 ### Contents
 1. [Background](#background)
 1. [Setting up git](#setting-up-git)
-1. [Basic Workflow](#basic-workflow)
-1. [Undoing Changes](#undoing-changes)
+1. [Creating a Repository](#creating-a-repository)
+1. [Tracking Changes](#tracking-changes)
 1. [Intro to GitHub](#intro-to-github)
 1. [Collaborating with GitHub](#collaborating-with-github)
+1. [BONUS](#bonus)
 1. [Glossary of terms](#glossary)
 
 ## Background
@@ -253,7 +254,7 @@ same commands to choose another editor or update your email address.
 
 [git-privacy]: https://help.github.com/articles/keeping-your-email-address-private/
 
-## Basic Workflow
+## Creating a Repository
 _[Back to top](#contents)_
 
 Once Git is configured, we can start using it.
@@ -443,7 +444,10 @@ wording of the output might be slightly different.
 {: .challenge}
 
 
-First let's make sure we're still in the right directory.
+## Tracking Changes
+_[Back to top](#contents)_
+
+Let's make sure we're still in the right directory.
 You should be in the `un-report` directory.
 
 ```
@@ -1185,7 +1189,7 @@ repository (`git commit`):
 > > ```
 > > {: .language-bash}
 > >
-> > Create your biography file `notes.txt` using `nano` or another text editor.
+> > Create your file `notes.txt` using `nano` or another text editor.
 > > Once in place, add and commit it to the repository:
 > >
 > > ```
@@ -1213,376 +1217,6 @@ repository (`git commit`):
 
 ## Undoing changes
 _[Back to top](#contents)_
-
-As we saw in the previous lesson, we can refer to commits by their
-identifiers.  You can refer to the _most recent commit_ of the working
-directory by using the identifier `HEAD`.
-
-We've been adding one line at a time to `notes.txt`, so it's easy to track our
-progress by looking, so let's do that using our `HEAD`s.  Before we start,
-let's make a change to `notes.txt`, adding yet another line.
-
-```
-$ nano notes.txt
-$ cat notes.txt
-```
-{: .language-bash}
-
-```
-We plotted life expectancy over time.
-Each point represents a country.
-Continents are grouped by color.
-An ill-considered change.
-```
-{: .output}
-
-Now, let's see what we get.
-
-```
-$ git diff HEAD notes.txt
-```
-{: .language-bash}
-
-```
-diff --git a/notes.txt b/notes.txt
-index b36abfd..0848c8d 100644
---- a/notes.txt
-+++ b/notes.txt
-@@ -1,3 +1,4 @@
- We plotted life expectancy over time.
- Each point represents a country.
- Continents are grouped by color.
-+An ill-considered change.
-```
-{: .output}
-
-which is the same as what you would get if you leave out `HEAD` (try it).  The
-real goodness in all this is when you can refer to previous commits.  We do
-that by adding `~1`
-(where "~" is "tilde", pronounced [**til**-d*uh*])
-to refer to the commit one before `HEAD`.
-
-```
-$ git diff HEAD~1 notes.txt
-```
-{: .language-bash}
-
-If we want to see the differences between older commits we can use `git diff`
-again, but with the notation `HEAD~1`, `HEAD~2`, and so on, to refer to them:
-
-```
-$ git diff HEAD~3 notes.txt
-```
-{: .language-bash}
-
-```
-diff --git a/notes.txt b/notes.txt
-index df0654a..b36abfd 100644
---- a/notes.txt
-+++ b/notes.txt
-@@ -1 +1,4 @@
- We plotted life expectancy over time.
-+Each point represents a country.
-+Continents are grouped by color.
-+An ill-considered change
-```
-{: .output}
-
-We could also use `git show` which shows us what changes we made at an older commit as
-well as the commit message, rather than the _differences_ between a commit and our
-working directory that we see by using `git diff`.
-
-```
-$ git show HEAD~3 notes.txt
-```
-{: .language-bash}
-
-```
-commit f22b25e3233b4645dabd0d81e651fe074bd8e73b
-Author: Riley Shor <Riley.Shor@fake.email.address>
-Date:   Thu Aug 22 09:51:46 2020 -0400
-
-    Make a change that I'll regret later
-
-diff --git a/notes.txt b/notes.txt
-new file mode 100644
-index 0000000..df0654a
---- /dev/null
-+++ b/notes.txt
-@@ -0,0 +1 @@
-+We plotted life expectancy over time.
-```
-{: .output}
-
-In this way,
-we can build up a chain of commits.
-The most recent end of the chain is referred to as `HEAD`;
-we can refer to previous commits using the `~` notation,
-so `HEAD~1`
-means "the previous commit",
-while `HEAD~123` goes back 123 commits from where we are now.
-
-We can also refer to commits using
-those long strings of digits and letters
-that `git log` displays.
-These are unique IDs for the changes,
-and "unique" really does mean unique:
-every change to any set of files on any computer
-has a unique 40-character identifier.
-Our first commit was given the ID
-`f22b25e3233b4645dabd0d81e651fe074bd8e73b`,
-so let's try this:
-
-```
-$ git diff f22b25e3233b4645dabd0d81e651fe074bd8e73b notes.txt
-```
-{: .language-bash}
-
-```
-diff --git a/notes.txt b/notes.txt
-index df0654a..93a3e13 100644
---- a/notes.txt
-+++ b/notes.txt
-@@ -1 +1,4 @@
- We plotted life expectancy over time.
-+Each point represents a country.
-+Continents are grouped by color.
-+An ill-considered change
-```
-{: .output}
-
-That's the right answer,
-but typing out random 40-character strings is annoying,
-so Git lets us use just the first few characters (typically seven for normal size projects):
-
-```
-$ git diff f22b25e notes.txt
-```
-{: .language-bash}
-
-```
-diff --git a/notes.txt b/notes.txt
-index df0654a..93a3e13 100644
---- a/notes.txt
-+++ b/notes.txt
-@@ -1 +1,4 @@
- We plotted life expectancy over time.
-+Each point represents a country.
-+Continents are grouped by color.
-+An ill-considered change
-```
-{: .output}
-
-All right! So
-we can save changes to files and see what we've changed. Now, how
-can we restore older versions of things?
-Let's suppose we change our mind about the last update to
-`notes.txt` (the "ill-considered change").
-
-`git status` now tells us that the file has been changed,
-but those changes haven't been staged:
-
-```
-$ git status
-```
-{: .language-bash}
-
-```
-On branch master
-Changes not staged for commit:
-  (use "git add <file>..." to update what will be committed)
-  (use "git checkout -- <file>..." to discard changes in working directory)
-
-    modified:   notes.txt
-
-no changes added to commit (use "git add" and/or "git commit -a")
-```
-{: .output}
-
-We can put things back the way they were
-by using `git checkout`:
-
-```
-$ git checkout HEAD notes.txt
-$ cat notes.txt
-```
-{: .language-bash}
-
-```
-We plotted life expectancy over time.
-Each point represents a country.
-Continents are grouped by color.
-```
-{: .output}
-
-As you might guess from its name,
-`git checkout` checks out (i.e., restores) an old version of a file.
-In this case,
-we're telling Git that we want to recover the version of the file recorded in `HEAD`,
-which is the last saved commit.
-If we want to go back even further,
-we can use a commit identifier instead:
-
-```
-$ git checkout f22b25e notes.txt
-```
-{: .language-bash}
-
-```
-$ cat notes.txt
-```
-{: .language-bash}
-
-```
- We plotted life expectancy over time.
-```
-{: .output}
-
-```
-$ git status
-```
-{: .language-bash}
-
-```
-On branch master
-Changes to be committed:
-  (use "git reset HEAD <file>..." to unstage)
-
-    modified:   notes.txt
-
-```
-{: .output}
-
-Notice that the changes are currently in the staging area.
-Again, we can put things back the way they were
-by using `git checkout`:
-
-```
-$ git checkout HEAD notes.txt
-```
-{: .language-bash}
-
-> ## Don't Lose Your HEAD
->
-> Above we used
->
-> ```
-> $ git checkout f22b25e notes.txt
-> ```
-> {: .language-bash}
->
-> to revert `notes.txt` to its state after the commit `f22b25e`. But be careful!
-> The command `checkout` has other important functionalities and Git will misunderstand
-> your intentions if you are not accurate with the typing. For example,
-> if you forget `notes.txt` in the previous command.
->
-> ```
-> $ git checkout f22b25e
-> ```
-> {: .language-bash}
-> ```
-> Note: checking out 'f22b25e'.
->
-> You are in 'detached HEAD' state. You can look around, make experimental
-> changes and commit them, and you can discard any commits you make in this
-> state without impacting any branches by performing another checkout.
->
-> If you want to create a new branch to retain commits you create, you may
-> do so (now or later) by using -b with the checkout command again. Example:
->
->  git checkout -b <new-branch-name>
->
-> HEAD is now at f22b25e Make a change that I'll regret later
-> ```
-> {: .error}
->
-> The "detached HEAD" is like "look, but don't touch" here,
-> so you shouldn't make any changes in this state.
-> After investigating your repo's past state, reattach your `HEAD` with `git checkout master`.
-{: .callout}
-
-It's important to remember that
-we must use the commit number that identifies the state of the repository
-*before* the change we're trying to undo.
-A common mistake is to use the number of
-the commit in which we made the change we're trying to discard.
-In the example below, we want to retrieve the state from before the most
-recent commit (`HEAD~1`), which is commit `f22b25e`:
-
-![Git Checkout]({{ page.root }}/fig/git/git-checkout.svg)
-
-We have now reverted our current file and commit to the latest version without the bug. But we have kept the commit and history from the commit that had the error.
-
-In the next section, we will learn how to share our git repository across networks. We can do this by creating a link to another location, like Github (remote repository) which we can `push` and `pull` our repository to and from to share our files with others as well as backing up our local repository.
-
-> ## Simplifying the Common Case
->
-> If you read the output of `git status` carefully,
-> you'll see that it includes this hint:
->
-> ```
-> (use "git checkout -- <file>..." to discard changes in working directory)
-> ```
-> {: .language-bash}
->
-> As it says,
-> `git checkout` without a version identifier restores files to the state saved in `HEAD`.
-> The double dash `--` is needed to separate the names of the files being recovered
-> from the command itself:
-> without it,
-> Git would try to use the name of the file as the commit identifier.
-{: .callout}
-
-The fact that files can be reverted one by one
-tends to change the way people organize their work.
-If everything is in one large document,
-it's hard (but not impossible) to undo changes to the introduction
-without also undoing changes made later to the conclusion.
-If the introduction and conclusion are stored in separate files,
-on the other hand,
-moving backward and forward in time becomes much easier.
-
-> ## Recovering Older Versions of a File
->
-> Jennifer has made changes to the Python script that she has been working on for weeks, and the
-> modifications she made this morning "broke" the script and it no longer runs. She has spent
-> ~ 1hr trying to fix it, with no luck...
->
-> Luckily, she has been keeping track of her project's versions using Git! Which commands below will
-> let her recover the last committed version of her Python script called
-> `data_cruncher.py`?
->
-> 1. `$ git checkout HEAD`
->
-> 2. `$ git checkout HEAD data_cruncher.py`
->
-> 3. `$ git checkout HEAD~1 data_cruncher.py`
->
-> 4. `$ git checkout <unique ID of last commit> data_cruncher.py`
->
-> 5. Both 2 and 4
->
->
-> > ## Solution
-> >
-> > The answer is (5)-Both 2 and 4.
-> >
-> > The `checkout` command restores files from the repository, overwriting the files in your working
-> > directory. Answers 2 and 4 both restore the *latest* version *in the repository* of the file
-> > `data_cruncher.py`. Answer 2 uses `HEAD` to indicate the *latest*, whereas answer 4 uses the
-> > unique ID of the last commit, which is what `HEAD` means.
-> >
-> > Answer 3 gets the version of `data_cruncher.py` from the commit *before* `HEAD`, which is NOT
-> > what we wanted.
-> >
-> > Answer 1 can be dangerous! Without a filename, `git checkout` will restore **all files**
-> > in the current directory (and all directories below it) to their state at the commit specified.
-> > This command will restore `data_cruncher.py` to the latest commit version, but it will also
-> > restore *any other files that are changed* to that version, erasing any changes you may
-> > have made to those files!
-> > As discussed above, you are left in a *detached* `HEAD` state, and you don't want to be there.
-> {: .solution}
-{: .challenge}
 
 > ## Reverting a Commit
 >
@@ -2213,5 +1847,389 @@ GitHub) are back in sync!
 > is known - its name. For example, one could use this to change `upstream` to `fred`.
 {: .callout}
 
+## Bonus
+_[Back to top](#contents)_
+
+- [Exploring History](#exploring-history)
+
+### Exploring history
+
+We can refer to commits by their identifiers shown in `log`. You can also refer
+to the _most recent commit_ of the working directory by using the identifier
+`HEAD`.
+
+We've been adding one line at a time to `notes.txt`, so it's easy to track our
+progress by looking, so let's do that using our `HEAD`s.  Before we start,
+let's make a change to `notes.txt`, adding yet another line.
+
+```
+$ nano notes.txt
+$ cat notes.txt
+```
+{: .language-bash}
+
+```
+We plotted life expectancy over time.
+Each point represents a country.
+Continents are grouped by color.
+An ill-considered change.
+```
+{: .output}
+
+Now, let's see what we get.
+
+```
+$ git diff HEAD notes.txt
+```
+{: .language-bash}
+
+```
+diff --git a/notes.txt b/notes.txt
+index b36abfd..0848c8d 100644
+--- a/notes.txt
++++ b/notes.txt
+@@ -1,3 +1,4 @@
+ We plotted life expectancy over time.
+ Each point represents a country.
+ Continents are grouped by color.
++An ill-considered change.
+```
+{: .output}
+
+which is the same as what you would get if you leave out `HEAD` (try it).  The
+real goodness in all this is when you can refer to previous commits.  We do
+that by adding `~1`
+(where "~" is "tilde", pronounced [**til**-d*uh*])
+to refer to the commit one before `HEAD`.
+
+```
+$ git diff HEAD~1 notes.txt
+```
+{: .language-bash}
+
+If we want to see the differences between older commits we can use `git diff`
+again, but with the notation `HEAD~1`, `HEAD~2`, and so on, to refer to them:
+
+```
+$ git diff HEAD~3 notes.txt
+```
+{: .language-bash}
+
+```
+diff --git a/notes.txt b/notes.txt
+index df0654a..b36abfd 100644
+--- a/notes.txt
++++ b/notes.txt
+@@ -1 +1,4 @@
+ We plotted life expectancy over time.
++Each point represents a country.
++Continents are grouped by color.
++An ill-considered change
+```
+{: .output}
+
+We could also use `git show` which shows us what changes we made at an older commit as
+well as the commit message, rather than the _differences_ between a commit and our
+working directory that we see by using `git diff`.
+
+```
+$ git show HEAD~3 notes.txt
+```
+{: .language-bash}
+
+```
+commit f22b25e3233b4645dabd0d81e651fe074bd8e73b
+Author: Riley Shor <Riley.Shor@fake.email.address>
+Date:   Thu Aug 22 09:51:46 2020 -0400
+
+    Make a change that I'll regret later
+
+diff --git a/notes.txt b/notes.txt
+new file mode 100644
+index 0000000..df0654a
+--- /dev/null
++++ b/notes.txt
+@@ -0,0 +1 @@
++We plotted life expectancy over time.
+```
+{: .output}
+
+In this way,
+we can build up a chain of commits.
+The most recent end of the chain is referred to as `HEAD`;
+we can refer to previous commits using the `~` notation,
+so `HEAD~1`
+means "the previous commit",
+while `HEAD~123` goes back 123 commits from where we are now.
+
+We can also refer to commits using
+those long strings of digits and letters
+that `git log` displays.
+These are unique IDs for the changes,
+and "unique" really does mean unique:
+every change to any set of files on any computer
+has a unique 40-character identifier.
+Our first commit was given the ID
+`f22b25e3233b4645dabd0d81e651fe074bd8e73b`,
+so let's try this:
+
+```
+$ git diff f22b25e3233b4645dabd0d81e651fe074bd8e73b notes.txt
+```
+{: .language-bash}
+
+```
+diff --git a/notes.txt b/notes.txt
+index df0654a..93a3e13 100644
+--- a/notes.txt
++++ b/notes.txt
+@@ -1 +1,4 @@
+ We plotted life expectancy over time.
++Each point represents a country.
++Continents are grouped by color.
++An ill-considered change
+```
+{: .output}
+
+That's the right answer,
+but typing out random 40-character strings is annoying,
+so Git lets us use just the first few characters (typically seven for normal size projects):
+
+```
+$ git diff f22b25e notes.txt
+```
+{: .language-bash}
+
+```
+diff --git a/notes.txt b/notes.txt
+index df0654a..93a3e13 100644
+--- a/notes.txt
++++ b/notes.txt
+@@ -1 +1,4 @@
+ We plotted life expectancy over time.
++Each point represents a country.
++Continents are grouped by color.
++An ill-considered change
+```
+{: .output}
+
+All right! So
+we can save changes to files and see what we've changed. Now, how
+can we restore older versions of things?
+Let's suppose we change our mind about the last update to
+`notes.txt` (the "ill-considered change").
+
+`git status` now tells us that the file has been changed,
+but those changes haven't been staged:
+
+```
+$ git status
+```
+{: .language-bash}
+
+```
+On branch master
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git checkout -- <file>..." to discard changes in working directory)
+
+    modified:   notes.txt
+
+no changes added to commit (use "git add" and/or "git commit -a")
+```
+{: .output}
+
+We can put things back the way they were
+by using `git checkout`:
+
+```
+$ git checkout HEAD notes.txt
+$ cat notes.txt
+```
+{: .language-bash}
+
+```
+We plotted life expectancy over time.
+Each point represents a country.
+Continents are grouped by color.
+```
+{: .output}
+
+As you might guess from its name,
+`git checkout` checks out (i.e., restores) an old version of a file.
+In this case,
+we're telling Git that we want to recover the version of the file recorded in `HEAD`,
+which is the last saved commit.
+If we want to go back even further,
+we can use a commit identifier instead:
+
+```
+$ git checkout f22b25e notes.txt
+```
+{: .language-bash}
+
+```
+$ cat notes.txt
+```
+{: .language-bash}
+
+```
+ We plotted life expectancy over time.
+```
+{: .output}
+
+```
+$ git status
+```
+{: .language-bash}
+
+```
+On branch master
+Changes to be committed:
+  (use "git reset HEAD <file>..." to unstage)
+
+    modified:   notes.txt
+
+```
+{: .output}
+
+Notice that the changes are currently in the staging area.
+Again, we can put things back the way they were
+by using `git checkout`:
+
+```
+$ git checkout HEAD notes.txt
+```
+{: .language-bash}
+
+> ## Don't Lose Your HEAD
+>
+> Above we used
+>
+> ```
+> $ git checkout f22b25e notes.txt
+> ```
+> {: .language-bash}
+>
+> to revert `notes.txt` to its state after the commit `f22b25e`. But be careful!
+> The command `checkout` has other important functionalities and Git will misunderstand
+> your intentions if you are not accurate with the typing. For example,
+> if you forget `notes.txt` in the previous command.
+>
+> ```
+> $ git checkout f22b25e
+> ```
+> {: .language-bash}
+> ```
+> Note: checking out 'f22b25e'.
+>
+> You are in 'detached HEAD' state. You can look around, make experimental
+> changes and commit them, and you can discard any commits you make in this
+> state without impacting any branches by performing another checkout.
+>
+> If you want to create a new branch to retain commits you create, you may
+> do so (now or later) by using -b with the checkout command again. Example:
+>
+>  git checkout -b <new-branch-name>
+>
+> HEAD is now at f22b25e Make a change that I'll regret later
+> ```
+> {: .error}
+>
+> The "detached HEAD" is like "look, but don't touch" here,
+> so you shouldn't make any changes in this state.
+> After investigating your repo's past state, reattach your `HEAD` with `git checkout master`.
+{: .callout}
+
+It's important to remember that
+we must use the commit number that identifies the state of the repository
+*before* the change we're trying to undo.
+A common mistake is to use the number of
+the commit in which we made the change we're trying to discard.
+In the example below, we want to retrieve the state from before the most
+recent commit (`HEAD~1`), which is commit `f22b25e`:
+
+![Git Checkout]({{ page.root }}/fig/git/git-checkout.svg)
+
+We have now reverted our current file and commit to the latest version without the bug. But we have kept the commit and history from the commit that had the error.
+
+In the next section, we will learn how to share our git repository across networks. We can do this by creating a link to another location, like Github (remote repository) which we can `push` and `pull` our repository to and from to share our files with others as well as backing up our local repository.
+
+> ## Simplifying the Common Case
+>
+> If you read the output of `git status` carefully,
+> you'll see that it includes this hint:
+>
+> ```
+> (use "git checkout -- <file>..." to discard changes in working directory)
+> ```
+> {: .language-bash}
+>
+> As it says,
+> `git checkout` without a version identifier restores files to the state saved in `HEAD`.
+> The double dash `--` is needed to separate the names of the files being recovered
+> from the command itself:
+> without it,
+> Git would try to use the name of the file as the commit identifier.
+{: .callout}
+
+The fact that files can be reverted one by one
+tends to change the way people organize their work.
+If everything is in one large document,
+it's hard (but not impossible) to undo changes to the introduction
+without also undoing changes made later to the conclusion.
+If the introduction and conclusion are stored in separate files,
+on the other hand,
+moving backward and forward in time becomes much easier.
+
+> ## Recovering Older Versions of a File
+>
+> Jennifer has made changes to the Python script that she has been working on for weeks, and the
+> modifications she made this morning "broke" the script and it no longer runs. She has spent
+> ~ 1hr trying to fix it, with no luck...
+>
+> Luckily, she has been keeping track of her project's versions using Git! Which commands below will
+> let her recover the last committed version of her Python script called
+> `data_cruncher.py`?
+>
+> 1. `$ git checkout HEAD`
+>
+> 2. `$ git checkout HEAD data_cruncher.py`
+>
+> 3. `$ git checkout HEAD~1 data_cruncher.py`
+>
+> 4. `$ git checkout <unique ID of last commit> data_cruncher.py`
+>
+> 5. Both 2 and 4
+>
+>
+> > ## Solution
+> >
+> > The answer is (5)-Both 2 and 4.
+> >
+> > The `checkout` command restores files from the repository, overwriting the files in your working
+> > directory. Answers 2 and 4 both restore the *latest* version *in the repository* of the file
+> > `data_cruncher.py`. Answer 2 uses `HEAD` to indicate the *latest*, whereas answer 4 uses the
+> > unique ID of the last commit, which is what `HEAD` means.
+> >
+> > Answer 3 gets the version of `data_cruncher.py` from the commit *before* `HEAD`, which is NOT
+> > what we wanted.
+> >
+> > Answer 1 can be dangerous! Without a filename, `git checkout` will restore **all files**
+> > in the current directory (and all directories below it) to their state at the commit specified.
+> > This command will restore `data_cruncher.py` to the latest commit version, but it will also
+> > restore *any other files that are changed* to that version, erasing any changes you may
+> > have made to those files!
+> > As discussed above, you are left in a *detached* `HEAD` state, and you don't want to be there.
+> {: .solution}
+{: .challenge}
+
+
 ## Glossary
 
+Commands:
+- `init` - creates a new git repository in your current working directory
+- `status` -
+
+Terms:
+- branch -

--- a/_episodes/03-intro-git-github.md
+++ b/_episodes/03-intro-git-github.md
@@ -2153,8 +2153,6 @@ recent commit (`HEAD~1`), which is commit `f22b25e`:
 
 We have now reverted our current file and commit to the latest version without the bug. But we have kept the commit and history from the commit that had the error.
 
-In the next section, we will learn how to share our git repository across networks. We can do this by creating a link to another location, like Github (remote repository) which we can `push` and `pull` our repository to and from to share our files with others as well as backing up our local repository.
-
 > ## Simplifying the Common Case
 >
 > If you read the output of `git status` carefully,

--- a/_episodes/03-intro-git-github.md
+++ b/_episodes/03-intro-git-github.md
@@ -1751,7 +1751,7 @@ GitHub) are back in sync!
 >
 > In practice, it is good to be sure that you have an updated version of the
 > repository you are collaborating on, so you should `git pull` before making
-> our changes. The basic collaborative workflow would be:
+> your changes. The basic collaborative workflow would be:
 >
 > * update your local repo with `git pull`,
 > * make your changes and stage them with `git add`,

--- a/_episodes/03-intro-git-github.md
+++ b/_episodes/03-intro-git-github.md
@@ -1759,7 +1759,7 @@ GitHub) are back in sync!
 > * upload the changes to GitHub with `git push`
 >
 > It is better to make many commits with smaller changes rather than
-> of one commit with massive changes: small commits are easier to
+> one commit with massive changes: small commits are easier to
 > read and review.
 {: .callout}
 

--- a/_episodes/03-intro-git-github.md
+++ b/_episodes/03-intro-git-github.md
@@ -1802,7 +1802,7 @@ GitHub) are back in sync!
 >
 > > ## Solution
 > >
-> > Automated back software gives you less control over how often backups are
+> > Automated backup software gives you less control over how often backups are
 > > created and it is often difficult to compare changes between backups.
 > > However, Git has a steeper learning curve than backup software.
 > > Advantages of using Git and GitHub for version control include:

--- a/_episodes/03-intro-git-github.md
+++ b/_episodes/03-intro-git-github.md
@@ -1771,7 +1771,7 @@ GitHub) are back in sync!
 > ## Review Changes
 >
 > The Owner pushed commits to the repository without giving any information
-> to the Collaborator. How can the Collaborator find out what has changed with
+> to the Collaborator. How can the Collaborator find out what has changed
 > on GitHub?
 >
 > > ## Solution


### PR DESCRIPTION
- Moved reset & checkout commands to bonus content (resolves #81).
- Added headings to break up the "basic workflow". The headings are similar to what [the original git lesson](http://swcarpentry.github.io/git-novice/) uses.
